### PR TITLE
chore: close v0.3 syscall issues in backlog sync artifacts

### DIFF
--- a/docs/issues/backlog.yaml
+++ b/docs/issues/backlog.yaml
@@ -234,7 +234,7 @@
       "type": "task",
       "labels": ["deferred", "syscall", "v0.3"],
       "milestone": "v0.3 Drishti Syscalls",
-      "status": "in-progress",
+      "status": "done",
       "depends_on": ["DRISHTI-001"],
       "body": "Implement raw syscall enter/exit tracing with latency histograms and error counters."
     },
@@ -245,7 +245,7 @@
       "labels": ["syscall", "rust", "v0.3"],
       "milestone": "v0.3 Drishti Syscalls",
       "parent_id": "DRISHTI-092",
-      "status": "in-progress",
+      "status": "done",
       "depends_on": ["DRISHTI-092"],
       "body": "Add syscall event structs in drishti-common plus collector config defaults and environment overrides."
     },
@@ -256,7 +256,7 @@
       "labels": ["syscall", "ebpf", "v0.3"],
       "milestone": "v0.3 Drishti Syscalls",
       "parent_id": "DRISHTI-092",
-      "status": "in-progress",
+      "status": "done",
       "depends_on": ["DRISHTI-120"],
       "body": "Implement raw_syscalls sys_enter/sys_exit tracing with bounded start timestamp maps and ring buffer events."
     },
@@ -267,7 +267,7 @@
       "labels": ["syscall", "daemon", "metrics", "v0.3"],
       "milestone": "v0.3 Drishti Syscalls",
       "parent_id": "DRISHTI-092",
-      "status": "in-progress",
+      "status": "done",
       "depends_on": ["DRISHTI-121"],
       "body": "Consume syscall events, export count/error/latency metrics, and enforce top-N + max_series cardinality controls."
     },
@@ -278,7 +278,7 @@
       "labels": ["syscall", "testing", "v0.3"],
       "milestone": "v0.3 Drishti Syscalls",
       "parent_id": "DRISHTI-092",
-      "status": "in-progress",
+      "status": "done",
       "depends_on": ["DRISHTI-122"],
       "body": "Add unit/integration and gated privileged smoke coverage for syscall collection and exporter paths."
     },
@@ -289,7 +289,7 @@
       "labels": ["syscall", "grafana", "docs", "v0.3"],
       "milestone": "v0.3 Drishti Syscalls",
       "parent_id": "DRISHTI-092",
-      "status": "in-progress",
+      "status": "done",
       "depends_on": ["DRISHTI-123"],
       "body": "Update Grafana dashboards and setup documentation for syscall metrics and configuration controls."
     },

--- a/docs/issues/generated/DRISHTI-010.md
+++ b/docs/issues/generated/DRISHTI-010.md
@@ -8,6 +8,3 @@ Labels: `build, rust, v0.1`
 Depends on: `DRISHTI-001`
 
 Create workspace crates (`drishti-common`, `drishti-ebpf`, `drishti-daemon`, `xtask`) and baseline automation (`Justfile`, rust-toolchain, clippy policy).
-
-## Dependency Links
-- #1

--- a/docs/issues/generated/DRISHTI-020.md
+++ b/docs/issues/generated/DRISHTI-020.md
@@ -8,6 +8,3 @@ Labels: `rust, ebpf, v0.1`
 Depends on: `DRISHTI-010`
 
 Define `#[repr(C)]` event and map structs in `drishti-common` for CPU, process lifecycle, and OOM paths.
-
-## Dependency Links
-- #2

--- a/docs/issues/generated/DRISHTI-030.md
+++ b/docs/issues/generated/DRISHTI-030.md
@@ -8,6 +8,3 @@ Labels: `ebpf, cpu, process, v0.1`
 Depends on: `DRISHTI-020`
 
 Add `sched_switch`, `sched_wakeup`, and `sched_process_*` tracepoint programs with bounded maps and ring buffer output.
-
-## Dependency Links
-- #3

--- a/docs/issues/generated/DRISHTI-040.md
+++ b/docs/issues/generated/DRISHTI-040.md
@@ -8,7 +8,3 @@ Labels: `daemon, collector, v0.1`
 Depends on: `DRISHTI-020, DRISHTI-030`
 
 Load/attach programs with partial-failure logging and route events to collector handlers with synthetic fallback support.
-
-## Dependency Links
-- #3
-- #4

--- a/docs/issues/generated/DRISHTI-050.md
+++ b/docs/issues/generated/DRISHTI-050.md
@@ -8,6 +8,3 @@ Labels: `memory, procfs, v0.1`
 Depends on: `DRISHTI-040`
 
 Poll `/proc` for per-process RSS/VSS/fault data and system memory totals, respecting include/exclude filters.
-
-## Dependency Links
-- #5

--- a/docs/issues/generated/DRISHTI-060.md
+++ b/docs/issues/generated/DRISHTI-060.md
@@ -8,7 +8,3 @@ Labels: `metrics, prometheus, v0.1`
 Depends on: `DRISHTI-040, DRISHTI-050`
 
 Expose `/metrics` and `/healthz`, register `drishti_*` metrics, and enforce `max_series` cardinality circuit breaker.
-
-## Dependency Links
-- #5
-- #6

--- a/docs/issues/generated/DRISHTI-070.md
+++ b/docs/issues/generated/DRISHTI-070.md
@@ -8,6 +8,3 @@ Labels: `grafana, deploy, v0.1`
 Depends on: `DRISHTI-060`
 
 Ship Grafana provisioning (datasource/dashboards), overview and process dashboards, docker compose, and hardened systemd unit.
-
-## Dependency Links
-- #7

--- a/docs/issues/generated/DRISHTI-080.md
+++ b/docs/issues/generated/DRISHTI-080.md
@@ -8,6 +8,3 @@ Labels: `ci, testing, v0.1`
 Depends on: `DRISHTI-060`
 
 Add CI jobs for fmt/clippy/tests, eBPF build path, and optional privileged smoke test execution.
-
-## Dependency Links
-- #7

--- a/docs/issues/generated/DRISHTI-090.md
+++ b/docs/issues/generated/DRISHTI-090.md
@@ -8,13 +8,3 @@ Labels: `deferred, network, v0.2`
 Depends on: `DRISHTI-001`
 
 Implement per-interface and per-process tx/rx telemetry and TCP RTT metrics in next milestone.
-
-## Dependency Links
-- #1
-
-## Sub-issues
-- [ ] https://github.com/singh-sumit/drishti/issues/16
-- [ ] https://github.com/singh-sumit/drishti/issues/17
-- [ ] https://github.com/singh-sumit/drishti/issues/18
-- [ ] https://github.com/singh-sumit/drishti/issues/19
-- [ ] https://github.com/singh-sumit/drishti/issues/20

--- a/docs/issues/generated/DRISHTI-091.md
+++ b/docs/issues/generated/DRISHTI-091.md
@@ -8,13 +8,3 @@ Labels: `deferred, disk, v0.2`
 Depends on: `DRISHTI-001`
 
 Implement block layer tracepoint collectors for throughput, latency, and queue depth.
-
-## Dependency Links
-- #1
-
-## Sub-issues
-- [ ] https://github.com/singh-sumit/drishti/issues/21
-- [ ] https://github.com/singh-sumit/drishti/issues/22
-- [ ] https://github.com/singh-sumit/drishti/issues/23
-- [ ] https://github.com/singh-sumit/drishti/issues/24
-- [ ] https://github.com/singh-sumit/drishti/issues/25

--- a/docs/issues/generated/DRISHTI-092.md
+++ b/docs/issues/generated/DRISHTI-092.md
@@ -2,19 +2,9 @@
 
 Local ID: `DRISHTI-092`
 Type: `task`
-Status: `in-progress`
+Status: `done`
 Milestone: `v0.3 Drishti Syscalls`
 Labels: `deferred, syscall, v0.3`
 Depends on: `DRISHTI-001`
 
 Implement raw syscall enter/exit tracing with latency histograms and error counters.
-
-## Dependency Links
-- #1
-
-## Sub-issues
-- [ ] https://github.com/singh-sumit/drishti/issues/27
-- [ ] https://github.com/singh-sumit/drishti/issues/28
-- [ ] https://github.com/singh-sumit/drishti/issues/29
-- [ ] https://github.com/singh-sumit/drishti/issues/30
-- [ ] https://github.com/singh-sumit/drishti/issues/31

--- a/docs/issues/generated/DRISHTI-093.md
+++ b/docs/issues/generated/DRISHTI-093.md
@@ -8,6 +8,3 @@ Labels: `deferred, qemu, ci, v0.4`
 Depends on: `DRISHTI-001`
 
 Run x86_64 and aarch64 integration checks under QEMU in CI.
-
-## Dependency Links
-- #1

--- a/docs/issues/generated/DRISHTI-094.md
+++ b/docs/issues/generated/DRISHTI-094.md
@@ -8,6 +8,3 @@ Labels: `deferred, build, optimization, v0.5`
 Depends on: `DRISHTI-001`
 
 Tune release settings and cross-build pipeline for static binaries and strict size targets.
-
-## Dependency Links
-- #1

--- a/docs/issues/generated/DRISHTI-100.md
+++ b/docs/issues/generated/DRISHTI-100.md
@@ -9,6 +9,3 @@ Parent: `DRISHTI-090`
 Depends on: `DRISHTI-090`
 
 Add network event structs in drishti-common, collector config keys, env overrides, and validation defaults.
-
-## Dependency Links
-- #10

--- a/docs/issues/generated/DRISHTI-101.md
+++ b/docs/issues/generated/DRISHTI-101.md
@@ -9,6 +9,3 @@ Parent: `DRISHTI-090`
 Depends on: `DRISHTI-100`
 
 Implement verifier-safe network probe paths and event emission for tx/rx, RTT, and retransmit signals.
-
-## Dependency Links
-- #16

--- a/docs/issues/generated/DRISHTI-102.md
+++ b/docs/issues/generated/DRISHTI-102.md
@@ -9,6 +9,3 @@ Parent: `DRISHTI-090`
 Depends on: `DRISHTI-101`
 
 Consume network events, aggregate counters/histograms, and expose drishti_net_* metric families.
-
-## Dependency Links
-- #17

--- a/docs/issues/generated/DRISHTI-103.md
+++ b/docs/issues/generated/DRISHTI-103.md
@@ -9,6 +9,3 @@ Parent: `DRISHTI-090`
 Depends on: `DRISHTI-102`
 
 Add unit/integration tests and gated privileged checks for network collectors.
-
-## Dependency Links
-- #18

--- a/docs/issues/generated/DRISHTI-104.md
+++ b/docs/issues/generated/DRISHTI-104.md
@@ -9,6 +9,3 @@ Parent: `DRISHTI-090`
 Depends on: `DRISHTI-103`
 
 Update configuration docs and Grafana dashboard panels for network telemetry metrics.
-
-## Dependency Links
-- #19

--- a/docs/issues/generated/DRISHTI-110.md
+++ b/docs/issues/generated/DRISHTI-110.md
@@ -9,6 +9,3 @@ Parent: `DRISHTI-091`
 Depends on: `DRISHTI-091`
 
 Add disk event structs in drishti-common, collector config keys, env overrides, and defaults.
-
-## Dependency Links
-- #11

--- a/docs/issues/generated/DRISHTI-111.md
+++ b/docs/issues/generated/DRISHTI-111.md
@@ -9,6 +9,3 @@ Parent: `DRISHTI-091`
 Depends on: `DRISHTI-110`
 
 Implement bounded in-flight request maps and completion latency computation for block I/O telemetry.
-
-## Dependency Links
-- #21

--- a/docs/issues/generated/DRISHTI-112.md
+++ b/docs/issues/generated/DRISHTI-112.md
@@ -9,6 +9,3 @@ Parent: `DRISHTI-091`
 Depends on: `DRISHTI-111`
 
 Consume disk events, aggregate counters/histograms/gauges, and expose drishti_disk_* metric families.
-
-## Dependency Links
-- #22

--- a/docs/issues/generated/DRISHTI-113.md
+++ b/docs/issues/generated/DRISHTI-113.md
@@ -9,6 +9,3 @@ Parent: `DRISHTI-091`
 Depends on: `DRISHTI-112`
 
 Add unit/integration tests and gated privileged checks for disk collectors.
-
-## Dependency Links
-- #23

--- a/docs/issues/generated/DRISHTI-114.md
+++ b/docs/issues/generated/DRISHTI-114.md
@@ -9,6 +9,3 @@ Parent: `DRISHTI-091`
 Depends on: `DRISHTI-113`
 
 Update configuration docs and Grafana dashboard panels for disk telemetry metrics.
-
-## Dependency Links
-- #24

--- a/docs/issues/generated/DRISHTI-120.md
+++ b/docs/issues/generated/DRISHTI-120.md
@@ -2,13 +2,10 @@
 
 Local ID: `DRISHTI-120`
 Type: `task`
-Status: `in-progress`
+Status: `done`
 Milestone: `v0.3 Drishti Syscalls`
 Labels: `syscall, rust, v0.3`
 Parent: `DRISHTI-092`
 Depends on: `DRISHTI-092`
 
 Add syscall event structs in drishti-common plus collector config defaults and environment overrides.
-
-## Dependency Links
-- #12

--- a/docs/issues/generated/DRISHTI-121.md
+++ b/docs/issues/generated/DRISHTI-121.md
@@ -2,13 +2,10 @@
 
 Local ID: `DRISHTI-121`
 Type: `task`
-Status: `in-progress`
+Status: `done`
 Milestone: `v0.3 Drishti Syscalls`
 Labels: `syscall, ebpf, v0.3`
 Parent: `DRISHTI-092`
 Depends on: `DRISHTI-120`
 
 Implement raw_syscalls sys_enter/sys_exit tracing with bounded start timestamp maps and ring buffer events.
-
-## Dependency Links
-- #27

--- a/docs/issues/generated/DRISHTI-122.md
+++ b/docs/issues/generated/DRISHTI-122.md
@@ -2,13 +2,10 @@
 
 Local ID: `DRISHTI-122`
 Type: `task`
-Status: `in-progress`
+Status: `done`
 Milestone: `v0.3 Drishti Syscalls`
 Labels: `syscall, daemon, metrics, v0.3`
 Parent: `DRISHTI-092`
 Depends on: `DRISHTI-121`
 
 Consume syscall events, export count/error/latency metrics, and enforce top-N + max_series cardinality controls.
-
-## Dependency Links
-- #28

--- a/docs/issues/generated/DRISHTI-123.md
+++ b/docs/issues/generated/DRISHTI-123.md
@@ -2,13 +2,10 @@
 
 Local ID: `DRISHTI-123`
 Type: `task`
-Status: `in-progress`
+Status: `done`
 Milestone: `v0.3 Drishti Syscalls`
 Labels: `syscall, testing, v0.3`
 Parent: `DRISHTI-092`
 Depends on: `DRISHTI-122`
 
 Add unit/integration and gated privileged smoke coverage for syscall collection and exporter paths.
-
-## Dependency Links
-- #29

--- a/docs/issues/generated/DRISHTI-124.md
+++ b/docs/issues/generated/DRISHTI-124.md
@@ -2,13 +2,10 @@
 
 Local ID: `DRISHTI-124`
 Type: `task`
-Status: `in-progress`
+Status: `done`
 Milestone: `v0.3 Drishti Syscalls`
 Labels: `syscall, grafana, docs, v0.3`
 Parent: `DRISHTI-092`
 Depends on: `DRISHTI-123`
 
 Update Grafana dashboards and setup documentation for syscall metrics and configuration controls.
-
-## Dependency Links
-- #30

--- a/docs/issues/generated/gh_commands.sh
+++ b/docs/issues/generated/gh_commands.sh
@@ -87,3 +87,9 @@ gh issue edit --repo singh-sumit/drishti 14 --title 'Deferred: musl static optim
 # close when mapped: DRISHTI-112 -> gh issue close --repo singh-sumit/drishti <issue-number>
 # close when mapped: DRISHTI-113 -> gh issue close --repo singh-sumit/drishti <issue-number>
 # close when mapped: DRISHTI-114 -> gh issue close --repo singh-sumit/drishti <issue-number>
+# close when mapped: DRISHTI-092 -> gh issue close --repo singh-sumit/drishti <issue-number>
+# close when mapped: DRISHTI-120 -> gh issue close --repo singh-sumit/drishti <issue-number>
+# close when mapped: DRISHTI-121 -> gh issue close --repo singh-sumit/drishti <issue-number>
+# close when mapped: DRISHTI-122 -> gh issue close --repo singh-sumit/drishti <issue-number>
+# close when mapped: DRISHTI-123 -> gh issue close --repo singh-sumit/drishti <issue-number>
+# close when mapped: DRISHTI-124 -> gh issue close --repo singh-sumit/drishti <issue-number>


### PR DESCRIPTION
## Summary
- mark `DRISHTI-092` and `DRISHTI-120..124` as `done` in `docs/issues/backlog.yaml`
- regenerate `docs/issues/generated/*` artifacts to match current backlog + GitHub mapping
- keep only `#13` (QEMU CI) and `#14` (musl packaging) open for next milestones

## Verification
- scripts/sync_github_issues.sh --repo singh-sumit/drishti --input docs/issues/backlog.yaml --apply
- gh issue list --repo singh-sumit/drishti --state open --json number,title
