### PR TITLE
fix(ci): stabilize qemu workflows across x86_64 and aarch64

### DIFF
--- a/.github/workflows/qemu-ci.yml
+++ b/.github/workflows/qemu-ci.yml
@@ -86,12 +86,24 @@ jobs:
           )
 
           apt-get "${APT_OPTS[@]}" update
+          IMAGE_PKG="$(
+            apt-cache "${APT_OPTS[@]}" -o "APT::Architecture=arm64" search '^linux-image-[0-9].*-generic$' \
+              | awk '{print $1}' \
+              | sort -V \
+              | tail -n 1
+          )"
+
+          if [[ -z "$IMAGE_PKG" ]]; then
+            echo "failed to resolve arm64 linux-image package from ports.ubuntu.com" >&2
+            exit 1
+          fi
+
           (
             cd "$APT_ROOT"
-            apt-get "${APT_OPTS[@]}" -o "APT::Architecture=arm64" download linux-image-virtual:arm64
+            apt-get "${APT_OPTS[@]}" -o "APT::Architecture=arm64" download "${IMAGE_PKG}:arm64"
           )
 
-          KERNEL_DEB="$(ls -1 "$APT_ROOT"/linux-image-virtual_*_arm64.deb | head -n 1)"
+          KERNEL_DEB="$(ls -1 "$APT_ROOT"/"${IMAGE_PKG}"_*_arm64.deb | head -n 1)"
           echo "DRISHTI_QEMU_AARCH64_KERNEL_DEB=$KERNEL_DEB" >> "$GITHUB_ENV"
       - name: Run aarch64 QEMU CI lane
         env:

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,5 @@
 [build.env]
-passthrough = ["DRISHTI_EMBEDDED_BPF_PATH"]
+passthrough = ["DRISHTI_EMBEDDED_BPF_PATH", "DRISHTI_EMBEDDED_BPF_META"]
 
 [target.aarch64-unknown-linux-musl]
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl:edge"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,3 +1,6 @@
+[build.env]
+passthrough = ["DRISHTI_EMBEDDED_BPF_PATH"]
+
 [target.aarch64-unknown-linux-musl]
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl:edge"
 

--- a/deploy/qemu/prepare.sh
+++ b/deploy/qemu/prepare.sh
@@ -30,7 +30,16 @@ command_exists() {
 
 is_readable_file() {
   local path="$1"
-  [[ -n "$path" && -f "$path" && -r "$path" ]]
+  [[ -n "$path" && -f "$path" ]] || return 1
+
+  local resolved="$path"
+  if [[ -L "$path" ]]; then
+    resolved="$(readlink -f "$path" 2>/dev/null || true)"
+    [[ -n "$resolved" && -f "$resolved" ]] || return 1
+  fi
+
+  [[ -r "$resolved" ]] || return 1
+  head -c 1 "$resolved" >/dev/null 2>&1
 }
 
 require_cmd() {
@@ -321,7 +330,7 @@ scrape_interval_ms = 1000
 max_series = 10000
 CFG
 
-cp "$KERNEL_SRC" "$KERNEL_OUT"
+cp -L "$KERNEL_SRC" "$KERNEL_OUT"
 
 (
   cd "$INITRAMFS_DIR"

--- a/drishti-daemon/build.rs
+++ b/drishti-daemon/build.rs
@@ -2,6 +2,7 @@ use std::{env, fs, path::PathBuf};
 
 fn main() {
     println!("cargo:rerun-if-env-changed=DRISHTI_EMBEDDED_BPF_PATH");
+    println!("cargo:rerun-if-env-changed=DRISHTI_EMBEDDED_BPF_META");
     println!("cargo:rerun-if-changed=../drishti-ebpf/src");
 
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR missing"));
@@ -9,11 +10,57 @@ fn main() {
 
     if let Ok(path) = env::var("DRISHTI_EMBEDDED_BPF_PATH") {
         let from = PathBuf::from(path);
-        if from.exists() {
-            let _ = fs::copy(from, &out_file);
-            return;
+        println!("cargo:rerun-if-changed={}", from.display());
+
+        let bytes = fs::read(&from).unwrap_or_else(|err| {
+            panic!(
+                "failed to read DRISHTI_EMBEDDED_BPF_PATH {}: {err}",
+                from.display()
+            )
+        });
+
+        if bytes.is_empty() {
+            panic!("embedded eBPF source object is empty: {}", from.display());
         }
+
+        if !looks_like_bpf_elf(&bytes) {
+            panic!(
+                "embedded eBPF source object is not an ELF64 eBPF object: {}",
+                from.display()
+            );
+        }
+
+        fs::write(&out_file, bytes)
+            .unwrap_or_else(|err| panic!("failed to write {}: {err}", out_file.display()));
+        return;
     }
 
-    let _ = fs::write(out_file, []);
+    fs::write(&out_file, [])
+        .unwrap_or_else(|err| panic!("failed to write {}: {err}", out_file.display()));
+}
+
+fn looks_like_bpf_elf(bytes: &[u8]) -> bool {
+    const ELF_MAGIC: &[u8; 4] = b"\x7fELF";
+    const ELF_CLASS_64: u8 = 2;
+    const ELFDATA2LSB: u8 = 1;
+    const ELFDATA2MSB: u8 = 2;
+    const EM_BPF: u16 = 247;
+
+    if bytes.len() < 20 {
+        return false;
+    }
+    if &bytes[0..4] != ELF_MAGIC {
+        return false;
+    }
+    if bytes[4] != ELF_CLASS_64 {
+        return false;
+    }
+
+    let machine = match bytes[5] {
+        ELFDATA2LSB => u16::from_le_bytes([bytes[18], bytes[19]]),
+        ELFDATA2MSB => u16::from_be_bytes([bytes[18], bytes[19]]),
+        _ => return false,
+    };
+
+    machine == EM_BPF
 }

--- a/drishti-daemon/src/loader.rs
+++ b/drishti-daemon/src/loader.rs
@@ -559,7 +559,15 @@ mod ebpf_runtime {
             );
         }
 
-        Ebpf::load(BPF_BYTES).context("failed to load embedded eBPF object")
+        // Keep an aligned view for parsers that assume natural alignment on strict-arch guests.
+        let align = std::mem::align_of::<u64>();
+        let mut storage = vec![0_u8; BPF_BYTES.len() + align];
+        let base = storage.as_ptr() as usize;
+        let offset = (align - (base % align)) % align;
+        let aligned = &mut storage[offset..offset + BPF_BYTES.len()];
+        aligned.copy_from_slice(BPF_BYTES);
+
+        Ebpf::load(aligned).context("failed to load embedded eBPF object")
     }
 
     fn attach_tracepoint(

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -243,6 +243,7 @@ fn qemu_ci(arch: QemuArch, kvm: KvmMode, timeout_secs: u64, skip_build: bool) ->
 fn build_qemu_binaries(arch: QemuArch) -> Result<()> {
     build_ebpf("nightly", "bpfel-unknown-none")?;
     let ebpf_object = find_ebpf_object()?;
+    let ebpf_fingerprint = ebpf_object_fingerprint(&ebpf_object)?;
 
     let target = arch.default_target();
     let build_tool = select_build_tool(arch);
@@ -271,6 +272,7 @@ fn build_qemu_binaries(arch: QemuArch) -> Result<()> {
         "qemu_smoke",
     ]);
     command.env("DRISHTI_EMBEDDED_BPF_PATH", &embedded_bpf_path);
+    command.env("DRISHTI_EMBEDDED_BPF_META", &ebpf_fingerprint);
 
     let status = command
         .status()
@@ -337,7 +339,7 @@ fn find_ebpf_object() -> Result<PathBuf> {
     ];
 
     for candidate in candidates {
-        if candidate.exists() {
+        if candidate.exists() && is_ebpf_elf(&candidate)? {
             return Ok(candidate);
         }
     }
@@ -356,7 +358,10 @@ fn find_ebpf_object() -> Result<PathBuf> {
                 .file_name()
                 .map(|value| value.to_string_lossy())
                 .unwrap_or_default();
-            if file_name.starts_with("drishti_ebpf-") && !file_name.ends_with(".d") {
+            if file_name.starts_with("drishti_ebpf-")
+                && !file_name.ends_with(".d")
+                && is_ebpf_elf(&path)?
+            {
                 return Ok(path);
             }
         }
@@ -365,6 +370,45 @@ fn find_ebpf_object() -> Result<PathBuf> {
     bail!(
         "unable to find compiled eBPF object under target/bpfel-unknown-none/release; run `cargo run -p xtask -- build-ebpf` and ensure drishti-ebpf binary target builds"
     )
+}
+
+fn ebpf_object_fingerprint(path: &Path) -> Result<String> {
+    let metadata = fs::metadata(path)
+        .with_context(|| format!("failed to stat eBPF object at {}", path.display()))?;
+    let modified_nanos = metadata
+        .modified()
+        .ok()
+        .and_then(|value| value.duration_since(UNIX_EPOCH).ok())
+        .map_or(0_u128, |value| value.as_nanos());
+    Ok(format!("{}:{modified_nanos}", metadata.len()))
+}
+
+fn is_ebpf_elf(path: &Path) -> Result<bool> {
+    const ELF_MAGIC: &[u8; 4] = b"\x7fELF";
+    const ELF_CLASS_64: u8 = 2;
+    const ELFDATA2LSB: u8 = 1;
+    const ELFDATA2MSB: u8 = 2;
+    const EM_BPF: u16 = 247;
+
+    let bytes = fs::read(path)
+        .with_context(|| format!("failed to read potential eBPF object {}", path.display()))?;
+    if bytes.len() < 20 {
+        return Ok(false);
+    }
+    if &bytes[0..4] != ELF_MAGIC {
+        return Ok(false);
+    }
+    if bytes[4] != ELF_CLASS_64 {
+        return Ok(false);
+    }
+
+    let machine = match bytes[5] {
+        ELFDATA2LSB => u16::from_le_bytes([bytes[18], bytes[19]]),
+        ELFDATA2MSB => u16::from_be_bytes([bytes[18], bytes[19]]),
+        _ => return Ok(false),
+    };
+
+    Ok(machine == EM_BPF)
 }
 
 fn daemon_binary_path(arch: QemuArch) -> PathBuf {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -249,6 +249,11 @@ fn build_qemu_binaries(arch: QemuArch) -> Result<()> {
     if build_tool == "cargo" {
         ensure_rust_target_installed(target)?;
     }
+    let embedded_bpf_path = if build_tool == "cross" {
+        to_cross_container_path(&ebpf_object)?
+    } else {
+        ebpf_object
+    };
 
     let mut command = Command::new(&build_tool);
     command.args([
@@ -265,7 +270,7 @@ fn build_qemu_binaries(arch: QemuArch) -> Result<()> {
         "--bin",
         "qemu_smoke",
     ]);
-    command.env("DRISHTI_EMBEDDED_BPF_PATH", &ebpf_object);
+    command.env("DRISHTI_EMBEDDED_BPF_PATH", &embedded_bpf_path);
 
     let status = command
         .status()
@@ -276,6 +281,19 @@ fn build_qemu_binaries(arch: QemuArch) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn to_cross_container_path(host_path: &Path) -> Result<PathBuf> {
+    let root = workspace_root();
+    let relative = host_path.strip_prefix(&root).with_context(|| {
+        format!(
+            "failed to map {} into cross container path; expected it under workspace {}",
+            host_path.display(),
+            root.display()
+        )
+    })?;
+
+    Ok(Path::new("/project").join(relative))
 }
 
 fn ensure_rust_target_installed(target: &str) -> Result<()> {


### PR DESCRIPTION
## Summary\n- fix x86_64 QEMU kernel selection on GitHub runners where  is unreadable\n- harden eBPF object selection/embedding for cross builds (strict ELF eBPF validation + deterministic embed metadata)\n- align embedded eBPF bytes before  to avoid aarch64 parse failures\n\n## Validation\n- \n- \n- 
running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 12 tests
test aggregator::tests::normalize_comm_strips_invalid_characters ... ok
test config::tests::parse_defaults_from_empty_config ... ok
test config::tests::parse_collector_bool_shorthand ... ok
test aggregator::tests::syscall_name_fallback_is_deterministic ... ok
test procfs::tests::collect_reads_mock_proc_fixture ... ok
test aggregator::tests::record_network_and_disk_metrics ... ok
test config::tests::env_overrides_apply ... ok
test aggregator::tests::series_limit_drops_extra_series ... ok
test aggregator::tests::record_syscall_metrics_and_top_n_collapse ... ok
test procfs::tests::parse_meminfo_extracts_key_fields ... ok
test procfs::tests::parse_stat_extracts_comm_and_faults ... ok
test procfs::tests::parse_statm_extracts_memory_sizes ... ok

test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 2 tests
test disabled_collectors_do_not_emit_cpu_process_network_disk_syscall_series ... ok
test metrics_endpoint_exposes_core_series ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.63s


running 1 test
test privileged_loader_smoke ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s\n- \n\n## Workflow Evidence\n- qemu-ci (x86_64 + aarch64): https://github.com/singh-sumit/drishti/actions/runs/22590683608\n- ci: https://github.com/singh-sumit/drishti/actions/runs/22590875741\n- docs: https://github.com/singh-sumit/drishti/actions/runs/22590877273\n